### PR TITLE
Update package.json for required nodejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "type": "git",
     "url": "https://github.com/devtanc/aws-profile-switcher.git"
   },
+  "engines": {
+    "node": ">=6.0"
+  },
   "dependencies": {
     "chalk": "^1.1.3",
     "commander": "^2.9.0",


### PR DESCRIPTION
Switcher will not run under node.js v4. Adding this in package.json makes that clear to the user.

Under v4:

```
$ switcher
/usr/local/lib/node_modules/aws-profile-switcher/switcher.js:167
            const [, name] = matches;
                  ^

SyntaxError: Unexpected token [
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/aws-profile-switcher/cli.js:7:18)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
```