### PR TITLE
Ignore keys that are not predefined

### DIFF
--- a/switcher.js
+++ b/switcher.js
@@ -191,7 +191,11 @@ class Switcher {
             Object.keys(p).length < 3
           );
 
-          profile[key] = value;
+          // Only allow valid keys i.e. ignore aws_session_token
+          if (key == "aws_access_key_id" || key == "aws_secret_access_key" || key == "ACCESS_KEY_ID" || key == "SECRET_ACCESS_KEY") {
+            profile[key] = value;
+          }
+          
           return prev;
         }, []); // Pass in an empty array to start the reduce
 


### PR DESCRIPTION
If the `credentials` file contains a key other than what it is expecting, it would fail. For example, in my case my `credentials` file also includes `aws_session_token`. The change ignores any key that is not in the predefined list.