### PR TITLE
Adding support for windows CRLF instead unix LF only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "after"
     ],
     "rules": {
+      "linebreak-style": 0,
       "camelcase": [
         "off"
       ],

--- a/switcher.js
+++ b/switcher.js
@@ -123,14 +123,13 @@ class Switcher {
    */
   _checkCredentialsFile() {
     const contents = fs.readFileSync(`${this.awsDir}/credentials`, 'utf8');
+
     if (contents === '') {
       return 'empty';
     }
-    const regexMatch = contents.match(/\[.*\]\n* *aws_access_key_id *= *[A-Z0-9]+\n* *aws_secret_access_key *= *.*/);
-    if (regexMatch) {
-      return 'good';
-    }
-    return 'bad';
+
+    const regexMatch = contents.match(/\[.*\](\n|\r)* *aws_access_key_id *= *[A-Z0-9]+(\n|\r)* *aws_secret_access_key *= *.*/);
+    return regexMatch ? 'good' : 'bad';
   }
 
   /**
@@ -148,6 +147,7 @@ class Switcher {
         }
 
         // Separate into lines
+        data = data.replace(/\r/g, '');
         data = data.split('\n');
 
         // Reduce the lines into an array of profile objects


### PR DESCRIPTION
I use windows sometimes (please don't judge me) and I couldn't use switcher because there was some formatting error, with a deep look the error was in the regex checker function, so I made little changes to work both with LF unix style `\n` as CRLF windows style `\n\r`.

all tests passed.

![test](https://user-images.githubusercontent.com/12099720/55989916-d160e880-5c7c-11e9-9615-2c1ff9e7941f.png)

